### PR TITLE
Refactor backend bootstrapping into microkernel architecture

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,3 +1,9 @@
+"""Runtime configuration helpers for the MIWA backend."""
+
+from __future__ import annotations
+
+from typing import Optional
+
 from pydantic_settings import BaseSettings
 
 
@@ -35,5 +41,42 @@ class Settings(BaseSettings):
     def COGNITO_JWKS_URL(self) -> str:
         return f"{self.COGNITO_ISSUER}/.well-known/jwks.json"
 
+    @property
+    def DATABASE_URL(self) -> str:
+        """Build the SQLAlchemy database URL from the configured credentials."""
 
-settings = Settings()
+        return (
+            f"postgresql+psycopg2://{self.DB_USER}:{self.DB_PASSWORD}"
+            f"@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+        )
+
+
+_settings: Optional[Settings] = None
+
+
+def set_settings(settings: Settings) -> None:
+    """Set the singleton settings instance used across the application."""
+
+    global _settings
+    _settings = settings
+
+
+def get_settings() -> Settings:
+    """Return the active settings instance, loading it from the environment if needed."""
+
+    global _settings
+    if _settings is None:
+        _settings = Settings()
+    return _settings
+
+
+class SettingsProxy:
+    """Lazy proxy that defers attribute access to the active settings instance."""
+
+    def __getattr__(self, item: str):  # type: ignore[override]
+        return getattr(get_settings(), item)
+
+
+settings = SettingsProxy()
+
+__all__ = ["Settings", "get_settings", "set_settings", "settings"]

--- a/backend/kernel/__init__.py
+++ b/backend/kernel/__init__.py
@@ -1,0 +1,6 @@
+"""Kernel package exposing the runtime entrypoints."""
+
+from .kernel import Kernel
+from .plugin import ServicePlugin
+
+__all__ = ["Kernel", "ServicePlugin"]

--- a/backend/kernel/kernel.py
+++ b/backend/kernel/kernel.py
@@ -1,0 +1,113 @@
+"""Microkernel bootstrapper that wires FastAPI, infrastructure and plugins."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from fastapi import APIRouter, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from core.config import Settings, get_settings, set_settings
+from database import configure_database, get_db, get_session_factory
+
+from .plugin import ServicePlugin
+from .runtime import set_kernel
+
+
+CapabilityFactory = Callable[["Kernel"], Any]
+
+
+class Kernel:
+    """Application runtime that coordinates shared infrastructure and plugins."""
+
+    def __init__(
+        self,
+        *,
+        settings: Optional[Settings] = None,
+        debug: Optional[bool] = None,
+        title: str = "MIWA Backend",
+    ) -> None:
+        self.settings = settings or get_settings()
+        set_settings(self.settings)
+        self.debug = bool(debug) if debug is not None else False
+
+        self.app = FastAPI(debug=self.debug, title=title)
+        self.app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        self._capability_factories: Dict[str, CapabilityFactory] = {}
+        self._capability_cache: Dict[str, Any] = {}
+        self._capability_singletons: Dict[str, bool] = {}
+        self._registered_plugins: Dict[str, ServicePlugin] = {}
+
+        set_kernel(self)
+        self._bootstrap_infrastructure()
+
+    # ------------------------------------------------------------------
+    # Capability and dependency management
+    # ------------------------------------------------------------------
+    def register_capability(
+        self,
+        name: str,
+        factory: CapabilityFactory,
+        *,
+        singleton: bool = True,
+    ) -> None:
+        """Register a lazily-created capability that other modules can resolve."""
+
+        if name in self._capability_factories:
+            raise ValueError(f"Capability '{name}' already registered")
+        self._capability_factories[name] = factory
+        self._capability_singletons[name] = singleton
+
+    def resolve(self, name: str) -> Any:
+        if name not in self._capability_factories:
+            raise KeyError(f"Capability '{name}' is not registered")
+
+        if name in self._capability_cache:
+            return self._capability_cache[name]
+
+        instance = self._capability_factories[name](self)
+        if self._capability_singletons.get(name, True):
+            self._capability_cache[name] = instance
+        return instance
+
+    # ------------------------------------------------------------------
+    # Router helpers
+    # ------------------------------------------------------------------
+    def include_router(self, router: APIRouter, *, prefix: str = "") -> None:
+        self.app.include_router(router, prefix=prefix)
+
+    # ------------------------------------------------------------------
+    # Plugin lifecycle
+    # ------------------------------------------------------------------
+    def register_plugin(self, plugin: ServicePlugin) -> None:
+        if plugin.name in self._registered_plugins:
+            raise ValueError(f"Plugin '{plugin.name}' already registered")
+        plugin.setup(self)
+        self._registered_plugins[plugin.name] = plugin
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _bootstrap_infrastructure(self) -> None:
+        """Initialise shared infrastructure managed by the kernel."""
+
+        configure_database(self.settings, echo=self.debug)
+        # Expose frequently used capabilities
+        self.register_capability("settings", lambda _: self.settings)
+        self.register_capability("db_session_factory", lambda _: get_session_factory())
+
+    @property
+    def get_db_dependency(self) -> Callable[..., Any]:
+        """Expose the shared database dependency for FastAPI routers."""
+
+        return get_db
+
+
+__all__ = ["Kernel"]

--- a/backend/kernel/plugin.py
+++ b/backend/kernel/plugin.py
@@ -1,0 +1,21 @@
+"""Plugin contract definition for services that participate in the kernel."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+if False:  # pragma: no cover - imported for type checking only
+    from .kernel import Kernel
+
+
+class ServicePlugin(ABC):
+    """Base contract that every service plugin must implement."""
+
+    name: str
+
+    @abstractmethod
+    def setup(self, kernel: "Kernel") -> None:
+        """Hook invoked by the kernel during bootstrapping."""
+
+
+__all__ = ["ServicePlugin"]

--- a/backend/kernel/runtime.py
+++ b/backend/kernel/runtime.py
@@ -1,0 +1,29 @@
+"""Global runtime registry that exposes the active kernel instance."""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .kernel import Kernel
+
+
+_kernel: Optional["Kernel"] = None
+
+
+def set_kernel(kernel: "Kernel") -> None:
+    """Register the bootstrapped kernel so other modules can access it lazily."""
+
+    global _kernel
+    _kernel = kernel
+
+
+def get_kernel() -> "Kernel":
+    """Return the active kernel instance."""
+
+    if _kernel is None:
+        raise RuntimeError("Kernel has not been initialised yet")
+    return _kernel
+
+
+__all__ = ["get_kernel", "set_kernel"]

--- a/backend/services/auth_service/plugin.py
+++ b/backend/services/auth_service/plugin.py
@@ -1,0 +1,19 @@
+"""Authentication plugin wiring the existing routers into the kernel."""
+
+from __future__ import annotations
+
+from kernel import Kernel, ServicePlugin
+
+from .cognito_router import router as cognito_router
+from .router import router as auth_router
+
+
+class AuthPlugin(ServicePlugin):
+    name = "auth"
+
+    def setup(self, kernel: Kernel) -> None:
+        kernel.include_router(auth_router, prefix="/api")
+        kernel.include_router(cognito_router, prefix="/api")
+
+
+__all__ = ["AuthPlugin"]

--- a/backend/services/calendar_service/plugin.py
+++ b/backend/services/calendar_service/plugin.py
@@ -1,0 +1,19 @@
+"""Calendar plugin bundling integration and calendar routers."""
+
+from __future__ import annotations
+
+from kernel import Kernel, ServicePlugin
+
+from .calendar_router import router as calendar_router
+from .integration_router import router as integration_router
+
+
+class CalendarPlugin(ServicePlugin):
+    name = "calendar"
+
+    def setup(self, kernel: Kernel) -> None:
+        kernel.include_router(integration_router, prefix="/api")
+        kernel.include_router(calendar_router, prefix="/api")
+
+
+__all__ = ["CalendarPlugin"]

--- a/backend/services/s3_service/deps.py
+++ b/backend/services/s3_service/deps.py
@@ -1,8 +1,28 @@
-from core.config import settings
-from functools import lru_cache
+"""Dependency helpers for the S3 plugin."""
+
+from __future__ import annotations
+
+from kernel import Kernel
+from kernel.runtime import get_kernel
+
 from .functions import S3Storage
 
 
-@lru_cache(maxsize=1)
+CAPABILITY_NAME = "capability.storage.s3"
+
+
+def register_s3_dependency(kernel: Kernel) -> None:
+    """Expose the shared S3 storage capability through the kernel."""
+
+    def _factory(k: Kernel) -> S3Storage:
+        settings = k.settings
+        return S3Storage(bucket=settings.S3_BUCKET_ARN, region=settings.AWS_REGION)
+
+    kernel.register_capability(CAPABILITY_NAME, _factory)
+
+
 def get_s3_storage() -> S3Storage:
-    return S3Storage(bucket=settings.S3_BUCKET_ARN, region=settings.AWS_REGION)
+    """FastAPI dependency used by routers to access the S3 storage service."""
+
+    kernel = get_kernel()
+    return kernel.resolve(CAPABILITY_NAME)

--- a/backend/services/s3_service/plugin.py
+++ b/backend/services/s3_service/plugin.py
@@ -1,0 +1,19 @@
+"""S3 service plugin wiring its router and storage capability."""
+
+from __future__ import annotations
+
+from kernel import Kernel, ServicePlugin
+
+from .deps import register_s3_dependency
+from .router import router
+
+
+class S3Plugin(ServicePlugin):
+    name = "storage.s3"
+
+    def setup(self, kernel: Kernel) -> None:
+        register_s3_dependency(kernel)
+        kernel.include_router(router, prefix="/api")
+
+
+__all__ = ["S3Plugin"]


### PR DESCRIPTION
## Summary
- introduce a kernel package that centralizes configuration, database wiring, and plugin registration
- convert the FastAPI bootstrap to build the kernel and register auth, storage, and calendar plugins
- expose the S3 storage capability through the kernel while keeping service routers unchanged

## Testing
- pytest *(fails: missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dd408148888330a8ed94c95b4f8dfa