### PR TITLE
Add environment variable validation for CDK pipeline stacks

### DIFF
--- a/deploymentCDK/bin/deployment_cdk.ts
+++ b/deploymentCDK/bin/deployment_cdk.ts
@@ -5,11 +5,22 @@ import { MiwaFrontendPipelineStack } from "../lib/miwa-frontend-pipeline-stack";
 
 const app = new cdk.App();
 
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required to synthesize the CDK app.`);
+  }
+  return value;
+};
+
+const defaultAccount = process.env.CDK_DEFAULT_ACCOUNT;
+const defaultRegion = process.env.CDK_DEFAULT_REGION || "us-east-1";
+
 // Stack principal con ambos servicios
 const mainStack = new MiwaBackendStack(app, "MiwaMainStack", {
   env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION || "us-east-1",
+    account: defaultAccount,
+    region: defaultRegion,
   },
   domain: {
     hostedZoneId: process.env.HOSTED_ZONE_ID || "Z1234567890ABC",
@@ -19,47 +30,45 @@ const mainStack = new MiwaBackendStack(app, "MiwaMainStack", {
   },
 });
 
+const githubConnectionArn = requireEnv("GITHUB_CONNECTION_ARN");
+const backendRepoOwner = requireEnv("BACKEND_REPO_OWNER");
+const backendRepoName = requireEnv("BACKEND_REPO_NAME");
+const frontendRepoOwner = requireEnv("FRONTEND_REPO_OWNER");
+const frontendRepoName = requireEnv("FRONTEND_REPO_NAME");
+
 // Pipeline para el Backend
-const backendPipeline = new MiwaBackendPipelineStack(
-  app,
-  "MiwaBackendPipelineStack",
-  {
-    env: {
-      account: process.env.CDK_DEFAULT_ACCOUNT,
-      region: process.env.CDK_DEFAULT_REGION || "us-east-1",
-    },
-    source: {
-      connectionArn: process.env.GITHUB_CONNECTION_ARN!,
-      repositoryOwner: process.env.BACKEND_REPO_OWNER!,
-      repositoryName: process.env.BACKEND_REPO_NAME!,
-      branch: process.env.BACKEND_BRANCH || "main",
-    },
-    repository: mainStack.repository,
-    service: mainStack.backendService,
-    containerName: "miwa-backend",
-  }
-);
+const backendPipeline = new MiwaBackendPipelineStack(app, "MiwaBackendPipelineStack", {
+  env: {
+    account: defaultAccount,
+    region: defaultRegion,
+  },
+  source: {
+    connectionArn: githubConnectionArn,
+    repositoryOwner: backendRepoOwner,
+    repositoryName: backendRepoName,
+    branch: process.env.BACKEND_BRANCH || "main",
+  },
+  repository: mainStack.repository,
+  service: mainStack.backendService,
+  containerName: "miwa-backend",
+});
 
 // Pipeline para el Frontend
-const frontendPipeline = new MiwaFrontendPipelineStack(
-  app,
-  "MiwaFrontendPipelineStack",
-  {
-    env: {
-      account: process.env.CDK_DEFAULT_ACCOUNT,
-      region: process.env.CDK_DEFAULT_REGION || "us-east-1",
-    },
-    source: {
-      connectionArn: process.env.GITHUB_CONNECTION_ARN!,
-      repositoryOwner: process.env.FRONTEND_REPO_OWNER!,
-      repositoryName: process.env.FRONTEND_REPO_NAME!,
-      branch: process.env.FRONTEND_BRANCH || "main",
-    },
-    repository: mainStack.frontendRepository,
-    service: mainStack.frontendService,
-    containerName: "miwa-frontend",
-  }
-);
+const frontendPipeline = new MiwaFrontendPipelineStack(app, "MiwaFrontendPipelineStack", {
+  env: {
+    account: defaultAccount,
+    region: defaultRegion,
+  },
+  source: {
+    connectionArn: githubConnectionArn,
+    repositoryOwner: frontendRepoOwner,
+    repositoryName: frontendRepoName,
+    branch: process.env.FRONTEND_BRANCH || "main",
+  },
+  repository: mainStack.frontendRepository,
+  service: mainStack.frontendService,
+  containerName: "miwa-frontend",
+});
 
 // Dependencias
 backendPipeline.addDependency(mainStack);


### PR DESCRIPTION
## Summary
- add a helper to require the GitHub-related environment variables before constructing the pipeline stacks
- reuse the resolved account and region defaults when instantiating the backend and frontend pipeline stacks so undefined values are not passed through

## Testing
- npx ts-node --prefer-ts-exts bin/deployment_cdk.ts

------
https://chatgpt.com/codex/tasks/task_e_68ed41f0d9bc833099fb0d9eac337969