### PR TITLE
Handle invalid Google Calendar refresh tokens

### DIFF
--- a/backend/services/calendar_service/DynamoGoogleTable.py
+++ b/backend/services/calendar_service/DynamoGoogleTable.py
@@ -26,3 +26,6 @@ class DynamoGoogleTable:
     def load_tokens(self, user_sub: str):
         r = self.table.get_item(Key={"user_sub": user_sub})
         return r.get("Item")
+
+    def delete_tokens(self, user_sub: str):
+        self.table.delete_item(Key={"user_sub": user_sub})

--- a/backend/services/calendar_service/integrations/google/calendar.py
+++ b/backend/services/calendar_service/integrations/google/calendar.py
@@ -1,11 +1,16 @@
 # integrations/google/calendar.py
+import logging
+
 from googleapiclient.discovery import build
 from starlette.concurrency import run_in_threadpool
 from google.auth.transport.requests import Request as GRequest
+from google.auth.exceptions import RefreshError
+
 from ...integrations.google.tokens import build_creds
 from ...DynamoGoogleTable import DynamoGoogleTable
 
 dynamo_google_table = DynamoGoogleTable()
+logger = logging.getLogger(__name__)
 
 
 async def with_service(creds, fn):
@@ -18,7 +23,23 @@ async def ensure_creds(user_sub: str):
     if not item:
         return None
     creds = build_creds(item)
-    if creds and not creds.valid and creds.refresh_token:
-        creds.refresh(GRequest())
-        dynamo_google_table.save_tokens(user_sub, creds)  # persistir refresh
+    if not creds:
+        return None
+
+    if not creds.valid:
+        if creds.refresh_token:
+            try:
+                creds.refresh(GRequest())
+            except RefreshError as exc:
+                logger.warning(
+                    "No se pudo refrescar el token de Google Calendar para %s: %s",
+                    user_sub,
+                    exc,
+                )
+                dynamo_google_table.delete_tokens(user_sub)
+                return None
+            else:
+                dynamo_google_table.save_tokens(user_sub, creds)  # persistir refresh
+        else:
+            return None
     return creds


### PR DESCRIPTION
## Summary
- handle Google Calendar refresh failures by logging, clearing persisted tokens, and avoiding crashes
- add a Dynamo helper to remove stored Google credentials when they become invalid

## Testing
- not run (requires external Google/AWS credentials)


------
https://chatgpt.com/codex/tasks/task_e_68ed9884d55883308bf685cce35211c2