### PR TITLE
Normalize S3 bucket name when configuring storage

### DIFF
--- a/backend/services/s3_service/deps.py
+++ b/backend/services/s3_service/deps.py
@@ -8,6 +8,31 @@ from kernel.runtime import get_kernel
 from .functions import S3Storage
 
 
+def _normalize_bucket_name(bucket_identifier: str) -> str:
+    """Return a usable bucket name extracted from an ARN or URI string."""
+
+    bucket = bucket_identifier.strip()
+    if not bucket:
+        raise ValueError("S3 bucket identifier cannot be empty")
+
+    if bucket.startswith("arn:"):
+        # Standard bucket ARNs look like ``arn:aws:s3:::bucket-name``.
+        if ":::" in bucket:
+            bucket = bucket.split(":::")[-1]
+        else:
+            bucket = bucket.rsplit(":", 1)[-1]
+    elif bucket.startswith("s3://"):
+        bucket = bucket[5:]
+    # Remove any potential path component after the bucket name
+    if "/" in bucket:
+        bucket = bucket.split("/", 1)[0]
+
+    if not bucket:
+        raise ValueError("Could not determine S3 bucket name from identifier")
+
+    return bucket
+
+
 CAPABILITY_NAME = "capability.storage.s3"
 
 
@@ -16,7 +41,8 @@ def register_s3_dependency(kernel: Kernel) -> None:
 
     def _factory(k: Kernel) -> S3Storage:
         settings = k.settings
-        return S3Storage(bucket=settings.S3_BUCKET_ARN, region=settings.AWS_REGION)
+        bucket_name = _normalize_bucket_name(settings.S3_BUCKET_ARN)
+        return S3Storage(bucket=bucket_name, region=settings.AWS_REGION)
 
     kernel.register_capability(CAPABILITY_NAME, _factory)
 


### PR DESCRIPTION
## Summary
- add normalization helper to extract the actual S3 bucket name from ARN or URI identifiers
- ensure the S3 storage capability uses the normalized bucket name to avoid upload failures

## Testing
- pytest *(fails: missing httpx dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9d2a846883309fd252ec2828f1c0