### PR TITLE
Fix DynamoDB resource configuration for meetings repository

### DIFF
--- a/backend/services/meetings_service/repository.py
+++ b/backend/services/meetings_service/repository.py
@@ -34,7 +34,11 @@ class MeetingArtifactRepository:
     def _get_table(self):  # pragma: no cover - thin wrapper
         import boto3
 
-        resource = boto3.resource("dynamodb", region_name=self._client.meta.region_name)
+        kwargs = {"region_name": self._client.meta.region_name}
+        endpoint_url = getattr(self._client.meta, "endpoint_url", None)
+        if endpoint_url:
+            kwargs["endpoint_url"] = endpoint_url
+        resource = boto3.resource("dynamodb", **kwargs)
         return resource.Table(self._table_name)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure the meetings repository reuses the DynamoDB client endpoint when creating a resource table

## Testing
- not run (environment lacks AWS/DynamoDB setup)


------
https://chatgpt.com/codex/tasks/task_e_68f68e6b68b083308814e00b14728ab8